### PR TITLE
#163642659 API endpoint for deleting a party

### DIFF
--- a/server/controllers/PartyController.js
+++ b/server/controllers/PartyController.js
@@ -62,6 +62,28 @@ class PartyController {
       return res.status(200).json({ status: 200, data: rows[0] });
     });
   }
+
+  /**
+  * @static
+  * @param {object} req - The request payload recieved from the router
+  * @param {object} res - The response payload sent back from the controller
+  * @returns {object} - The particular party deleted
+  * @memberOf PartyController
+  */
+  static deleteParty(req, res) {
+    db.query(queries.deleteParty, [req.params.id], (err, dbRes) => {
+      if (err) {
+        return res.json({ sucess: false, message: 'Could not Delete entry', err });
+      }
+      if (dbRes.rowCount === 0) {
+        return res.json({ sucess: false, message: `Party with ID ${req.params.id} does not exist`, err });
+      }
+      return res.status(200).json({
+        status: 200,
+        data: `Party with ID ${req.params.id} was successfully deleted`,
+      });
+    });
+  }
 }
 
 export default PartyController;

--- a/server/model/queries.js
+++ b/server/model/queries.js
@@ -8,6 +8,8 @@ const getAnOfficeById = 'SELECT * FROM office WHERE id = $1';
 const getAllParties = 'SELECT * from party';
 const createParty = 'INSERT INTO party(name, hqaddress, logourl) values($1, $2, $3) RETURNING *';
 const getPartyById = 'SELECT * FROM party WHERE id = $1';
+const deleteParty = 'DELETE from party where id = $1';
+
 
 const Queries = {
   insertIntoUsers,
@@ -18,6 +20,7 @@ const Queries = {
   getAllParties,
   createParty,
   getPartyById,
+  deleteParty
 };
 
 export default Queries;

--- a/server/routes/parties.js
+++ b/server/routes/parties.js
@@ -3,7 +3,7 @@ import PartyController from '../controllers/PartyController';
 import PartyValidator from '../middleware/PartyValidator';
 
 const {
-  getAllParties, createParty, getAPartyById
+  getAllParties, createParty, getAPartyById, deleteParty
 } = PartyController;
 
 const {
@@ -16,6 +16,7 @@ const partyRouter = express.Router();
 partyRouter.get('/', getAllParties);
 partyRouter.post('/', createPartyValidator, createParty);
 partyRouter.get('/:id', getAPartyById);
+partyRouter.delete('/:id', deleteParty);
 
 
 export default partyRouter;


### PR DESCRIPTION
#### What does this PR do?
It's an API endpoint for deleting a specific party

#### Description of Task to be completed?
- Add parties route to handle an incoming delete request to this endpoint
- Add parties controller that contains logic for the response
- Add a query to persist data from the database

#### How should this be manually tested?
- clone this app to your local computer
- cd into Politico
- open your console/command line
- type in 'npm run dev'
- open your browser or your postman and on the url type in http://localhost:8000/api/v1/parties/:id
- a list of all the political parties should be displayed

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163642659](https://www.pivotaltracker.com/n/projects/2239146)

#### Screenshots (if appropriate)
![deleteparty route](https://user-images.githubusercontent.com/35389434/52099794-f0842f80-25d4-11e9-9701-201adc042d1f.PNG)

#### Questions:
N/A