### PR TITLE
#163642827 API endpoint for editing a given party name

### DIFF
--- a/server/controllers/PartyController.js
+++ b/server/controllers/PartyController.js
@@ -84,6 +84,31 @@ class PartyController {
       });
     });
   }
+
+  /**
+  * @static
+  * @param {object} req - The request payload recieved from the router
+  * @param {object} res - The response payload sent back from the controller
+  * @returns {object} - The particular party name edited
+  * @memberOf PartyController
+  */
+  static editParty(req, res) {
+    db.query(queries.updateParty, [req.body.name, req.params.id], (err, dbRes) => {
+      if (err) {
+        return res.json({ sucess: false, message: 'Could not update party', err });
+      }
+      if (dbRes.rowCount === 0) {
+        return res.json({ sucess: false, message: `Party with ID ${req.params.id} does not exist`, err });
+      }
+      return res.json({
+        status: 200,
+        data: {
+          id: req.params.id,
+          name: req.body.name
+        }
+      });
+    });
+  }
 }
 
 export default PartyController;

--- a/server/model/queries.js
+++ b/server/model/queries.js
@@ -9,6 +9,7 @@ const getAllParties = 'SELECT * from party';
 const createParty = 'INSERT INTO party(name, hqaddress, logourl) values($1, $2, $3) RETURNING *';
 const getPartyById = 'SELECT * FROM party WHERE id = $1';
 const deleteParty = 'DELETE from party where id = $1';
+const updateParty = 'UPDATE party SET name = $1 WHERE id = $2';
 
 
 const Queries = {
@@ -20,7 +21,8 @@ const Queries = {
   getAllParties,
   createParty,
   getPartyById,
-  deleteParty
+  deleteParty,
+  updateParty
 };
 
 export default Queries;

--- a/server/routes/parties.js
+++ b/server/routes/parties.js
@@ -3,7 +3,7 @@ import PartyController from '../controllers/PartyController';
 import PartyValidator from '../middleware/PartyValidator';
 
 const {
-  getAllParties, createParty, getAPartyById, deleteParty
+  getAllParties, createParty, getAPartyById, deleteParty, editParty
 } = PartyController;
 
 const {
@@ -17,6 +17,7 @@ partyRouter.get('/', getAllParties);
 partyRouter.post('/', createPartyValidator, createParty);
 partyRouter.get('/:id', getAPartyById);
 partyRouter.delete('/:id', deleteParty);
+partyRouter.patch('/:id/name', editParty);
 
 
 export default partyRouter;


### PR DESCRIPTION
#### What does this PR do?
It's an API endpoint for editing the name of a party

#### Description of Task to be completed?
- Add parties route to handle an incoming patch request to this endpoint
- Add parties controller that contains logic for the response
- Add a query to persist data from the database

#### How should this be manually tested?
- clone this app to your local computer
- open your console/command line
- type in 'npm run dev'
- open your browser or your postman and on the url type in http://localhost:8000/api/v1/parties/:id/name
- a list of all the political parties should be displayed

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163642827](https://www.pivotaltracker.com/n/projects/2239146)

#### Screenshots
![editname route](https://user-images.githubusercontent.com/35389434/52100309-44901380-25d7-11e9-8064-030e4e36665b.PNG)

#### Questions:
N/A