### PR TITLE
#163641628 API endpoint for registering a candidate and protection of admin routes

### DIFF
--- a/server/controllers/OfficeController.js
+++ b/server/controllers/OfficeController.js
@@ -61,6 +61,43 @@ class OfficeController {
       return res.status(200).json({ status: 200, data: rows[0] });
     });
   }
+
+  /**
+  * @static
+  * @param {object} req - The request payload recieved from the router
+  * @param {object} res - The response payload sent back from the controller
+  * @returns {object} - registered candidate
+  * @memberOf OfficeController
+  */
+  static registerCandidate(req, res) {
+    const { office, party } = req.body;
+
+    // check if user is already registerd
+    db.query(queries.getCandidate, [req.params.userId], (err, data) => {
+      if (err) {
+        return res.json({ status: 500, error: 'Cannot register at the moment' });
+      }
+      const { rowCount } = data;
+      if (rowCount === 0) {
+        db.query(queries.createCandidate, [office, party, req.params.userId], (err, dbRes) => {
+          if (err) {
+            return res.status(400).json({ status: 400, error: err });
+          }
+          const { rows } = dbRes;
+          const candidate = rows[0];
+          return res.status(201).json({
+            status: 201,
+            data: [{
+              office: candidate.office,
+              user: candidate.candidate
+            }]
+          });
+        });
+      } else {
+        return res.json({ status: 409, error: 'Candidate is already registerd' });
+      }
+    });
+  }
 }
 
 export default OfficeController;

--- a/server/middleware/authenticator.js
+++ b/server/middleware/authenticator.js
@@ -25,5 +25,27 @@ export default {
         next();
       });
     }
+  },
+
+  isAuthorised(req, res, next) {
+    const token = req.headers['x-access-token'];
+    if (!token) {
+      res.status(403)
+        .json({
+          success: false,
+          message: 'Missing Token'
+        });
+    } else {
+      jwt.verify(token, process.env.JWTKEY, (err, decoded) => {
+        if (err) {
+          return res.status(403).json({ message: 'Invalid token supplied' });
+        }
+        if (decoded.user.isAdmin !== 'true') {
+          return res.status(403).json({ message: 'UnAuthorised User' });
+        }
+        req.user = decoded.user;
+        next();
+      });
+    }
   }
 };

--- a/server/model/queries.js
+++ b/server/model/queries.js
@@ -11,6 +11,8 @@ const getPartyById = 'SELECT * FROM party WHERE id = $1';
 const deleteParty = 'DELETE from party where id = $1';
 const updateParty = 'UPDATE party SET name = $1 WHERE id = $2';
 
+const getCandidate = 'SELECT * FROM candidate WHERE candidate = $1';
+const createCandidate = 'INSERT INTO candidate(office, party, candidate) values($1, $2, $3) RETURNING *';
 
 const Queries = {
   insertIntoUsers,
@@ -22,7 +24,9 @@ const Queries = {
   createParty,
   getPartyById,
   deleteParty,
-  updateParty
+  updateParty,
+  getCandidate,
+  createCandidate
 };
 
 export default Queries;

--- a/server/routes/offices.js
+++ b/server/routes/offices.js
@@ -4,7 +4,7 @@ import OfficeVAlidator from '../middleware/OfficeValidator';
 import Authenticator from '../middleware/authenticator';
 
 const {
-  createOffice, getAllOffices, getAnOfficeById
+  createOffice, getAllOffices, getAnOfficeById, registerCandidate
 } = OfficeController;
 
 const {
@@ -13,8 +13,9 @@ const {
 
 const officeRouter = express.Router();
 
-officeRouter.post('/', createOfficeValidator, Authenticator.isAuthenticated, createOffice);
+officeRouter.post('/', createOfficeValidator, Authenticator.isAuthenticated, Authenticator.isAuthorised, createOffice);
 officeRouter.get('/', Authenticator.isAuthenticated, getAllOffices);
 officeRouter.get('/:id', Authenticator.isAuthenticated, getAnOfficeById);
+officeRouter.post('/:userId/register', Authenticator.isAuthenticated, registerCandidate);
 
 export default officeRouter;

--- a/server/routes/parties.js
+++ b/server/routes/parties.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import PartyController from '../controllers/PartyController';
 import PartyValidator from '../middleware/PartyValidator';
+import Authenticator from '../middleware/authenticator';
 
 const {
   getAllParties, createParty, getAPartyById, deleteParty, editParty
@@ -13,11 +14,11 @@ const {
 
 const partyRouter = express.Router();
 
-partyRouter.get('/', getAllParties);
-partyRouter.post('/', createPartyValidator, createParty);
-partyRouter.get('/:id', getAPartyById);
-partyRouter.delete('/:id', deleteParty);
-partyRouter.patch('/:id/name', editParty);
+partyRouter.get('/', Authenticator.isAuthenticated, getAllParties);
+partyRouter.post('/', Authenticator.isAuthenticated, Authenticator.isAuthorised, createPartyValidator, createParty);
+partyRouter.get('/:id', Authenticator.isAuthenticated, getAPartyById);
+partyRouter.delete('/:id', Authenticator.isAuthenticated, deleteParty);
+partyRouter.patch('/:id/name', Authenticator.isAuthenticated, editParty);
 
 
 export default partyRouter;


### PR DESCRIPTION
#### What does this PR do?
It registers a User that wish to run an office and protects admin routes

#### Description of Task to be completed?
- add controller for registering a user
- add route to handle post request to the endpoint
- add authentication for all route
- add authorization for dedicated admin routes
- add queries to create or get a candidate from the database

#### How should this be manually tested?
- clone this app to your local computer
- open your console/command line
- cd into Politico
- type in 'npm run dev'
- signup as a user and test accessing the admin dedicated POST routes http://localhost:8000/api/v1/parties/ or http://localhost:8000/api/v1/offices/
- an error should be outputted

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[163641628](https://www.pivotaltracker.com/n/projects/2239146)

#### Screenshots (if appropriate)
![protected admin route](https://user-images.githubusercontent.com/35389434/52102768-968a6680-25e2-11e9-9aba-1ffdd5616a6f.PNG)

#### Questions:
N/A


